### PR TITLE
Block on coroutines when preparing bundles for upload

### DIFF
--- a/Editor/AssetBundleBuilder.cs
+++ b/Editor/AssetBundleBuilder.cs
@@ -388,7 +388,7 @@ namespace SynapseGames.AssetBundle
                     }
 
                     // Set the hash for the current build target.
-                    var bundleTarget = GetBundleTarget(target);
+                    var bundleTarget = GetPlatformForTarget(target);
                     description.hashes[bundleTarget] = manifest.GetAssetBundleHash(bundleName);
                 }
             }
@@ -399,9 +399,9 @@ namespace SynapseGames.AssetBundle
         }
 
         /// <summary>
-        /// Gets the corresponding <see cref="AssetBundleTarget"/> for the specified <see cref="BuildTarget"/>.
+        /// Gets the corresponding <see cref="RuntimePlatform"/> for the specified <see cref="BuildTarget"/>.
         /// </summary>
-        public static RuntimePlatform GetBundleTarget(BuildTarget target)
+        public static RuntimePlatform GetPlatformForTarget(BuildTarget target)
         {
             switch (target)
             {
@@ -438,7 +438,7 @@ namespace SynapseGames.AssetBundle
         /// </summary>
         private static string GetBuildPathForBuildTarget(BuildTarget target)
         {
-            target = NormalizeBuildTarget(target);
+            var platform = GetPlatformForTarget(NormalizeBuildTarget(target));
             return Path.Combine(RootBuildPath, target.ToString());
         }
 
@@ -500,7 +500,7 @@ namespace SynapseGames.AssetBundle
             AssetBundleManifest manifest)
         {
             var buildDirectory = GetBuildPathForBuildTarget(buildTarget);
-            var target = GetBundleTarget(buildTarget);
+            var target = GetPlatformForTarget(buildTarget);
 
             foreach (var bundle in manifest.GetAllAssetBundles())
             {


### PR DESCRIPTION
This PR fixes an issue where `AssetBundleBuilder.PrepareBundlesForUpload()` would not run fully if running Unity in batch mode with the `-quit` flag. This was happening because Unity would not wait for the background coroutine to finish before quitting. To fix the issue, we need to block while waiting for the coroutines to finish if the editor is running in batch mode.

Additionally, I have fixed the naming convention used for the intermediate asset bundle build folders. They now are named based on the runtime platform (instead of the build target), which more accurately reflects the naming conventions for the asset bundles and avoids potential collisions in cases where more than one runtime platform maps to a single build target.