### PR TITLE
Change default handling in NormalizePlatform()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* `NormalizePlatform()` no longer throws an exception for "unsupported" platforms. ([#7])
+
+[#7]: https://github.com/kongregate/asset-bundle-builder/pull/7
+
 ## [v0.2.1]
 
 ### Added

--- a/Runtime/AssetBundleDescription.cs
+++ b/Runtime/AssetBundleDescription.cs
@@ -238,8 +238,7 @@ namespace SynapseGames.AssetBundle
                 case RuntimePlatform.LinuxPlayer:
                     return RuntimePlatform.LinuxPlayer;
 
-                default:
-                    throw new NotImplementedException($"Cannot determine asset bundle target for unsupported platform {Application.platform}");
+                default: return platform;
             }
         }
 


### PR DESCRIPTION
Change `AssetBundleDescription.NormalizePlatform()` to not throw an exception for an unknown platform type. `NormalizePlatform()` is only intended to normalize the platform while running in the editor, so there's no need to explicitly catch "unknown" platforms like that: It's reasonable to default to returning the same platform that was passed in.